### PR TITLE
FIX: Bad characters in extract due to preg_replace with php 7.0 and l…

### DIFF
--- a/core/components/simplesearch/model/simplesearch/simplesearch.class.php
+++ b/core/components/simplesearch/model/simplesearch/simplesearch.class.php
@@ -344,7 +344,7 @@ class SimpleSearch
      * @return string The generated extract.
      */
     public function createExtract($text, $length = 200, $search = '', $ellipsis = '...') {
-        $text = trim(preg_replace('/\s+/', ' ', $this->sanitize($text)));
+        $text = trim(preg_replace('/\s+/u', ' ', $this->sanitize($text)));
         if (empty($text)) {
             return '';
         }


### PR DESCRIPTION
simple correction to return expected characters by preg_replace in createExtract method in simplesearch.class.php

php 7.0.6 and lower (php 7.1.10 works ok)