### PR TITLE
Fix Sterc/SimpleSearch#31

### DIFF
--- a/core/components/simplesearch/model/simplesearch/driver/simplesearchdriverbasic.class.php
+++ b/core/components/simplesearch/model/simplesearch/driver/simplesearchdriverbasic.class.php
@@ -37,7 +37,7 @@ class SimpleSearchDriverBasic extends SimpleSearchDriver
         $exclude       = $this->modx->getOption('exclude', $scriptProperties, '');
         $useAllWords   = $this->modx->getOption('useAllWords', $scriptProperties, false);
         $searchStyle   = $this->modx->getOption('searchStyle', $scriptProperties, 'partial');
-        $hideMenu      = $this->modx->getOption('hideMenu', $scriptProperties, 2);
+        $hideMenu      = (int) $this->modx->getOption('hideMenu', $scriptProperties, 2);
         $maxWords      = $this->modx->getOption('maxWords', $scriptProperties, 7);
         $andTerms      = $this->modx->getOption('andTerms', $scriptProperties, true);
         $matchWildcard = $this->modx->getOption('matchWildcard', $scriptProperties, true);


### PR DESCRIPTION
### Why?
Currently hideMenu property is broken due to strict check on `core/components/simplesearch/model/simplesearch/driver/simplesearchdriverbasic.class.php:L240` and `$this->modx->getOption()` returns a string unless it is cast. The broken behaviour causes a lot of headaches—search results are just poor yet nothing in the debug.

### What does it do?
Casts the string to integer