### PR TITLE
Fixed incorrect triggering of the condition

### DIFF
--- a/core/components/simplesearch/model/simplesearch/simplesearch.class.php
+++ b/core/components/simplesearch/model/simplesearch/simplesearch.class.php
@@ -152,7 +152,7 @@ class SimpleSearch
         $reserved = array('AND', 'OR', 'IN', 'NOT');
         foreach ($this->searchArray as $key => $term) {
             $this->searchArray[$key] = strip_tags($term);
-            if (strlen($term) < $minChars && !in_array($term, $reserved)) {
+            if (strlen($term) < $minChars && in_array($term, $reserved)) {
                 unset($this->searchArray[$key]);
             }
         }

--- a/core/components/simplesearch/model/simplesearch/simplesearch.class.php
+++ b/core/components/simplesearch/model/simplesearch/simplesearch.class.php
@@ -144,7 +144,7 @@ class SimpleSearch
      * @return string The parsed and cleansed string.
      */
     public function parseSearchString($str = '') {
-        $minChars = $this->modx->getOption('minChars', $this->config, 4);
+        $minChars = $this->modx->getOption('minChars', $this->config, 3);
 
         $this->searchArray = explode(' ',$str);
         $this->searchArray = $this->modx->sanitize($this->searchArray, $this->modx->sanitizePatterns);

--- a/core/components/simplesearch/model/simplesearch/simplesearch.class.php
+++ b/core/components/simplesearch/model/simplesearch/simplesearch.class.php
@@ -152,7 +152,7 @@ class SimpleSearch
         $reserved = array('AND', 'OR', 'IN', 'NOT');
         foreach ($this->searchArray as $key => $term) {
             $this->searchArray[$key] = strip_tags($term);
-            if (strlen($term) < $minChars && in_array($term, $reserved)) {
+            if (iconv_strlen($term) < $minChars && in_array($term, $reserved)) {
                 unset($this->searchArray[$key]);
             }
         }


### PR DESCRIPTION
Fixed incorrect triggering of the condition:
- Removed the mistaken negation (why do we need the `$reserved` array at all?)
- Added accounting for encoding in calculating length

Also changed `minChars` according to the documentation (it says 3, not 4) - https://docs.modx.com/current/en/extras/simplesearch/simplesearch

Related issue https://github.com/Sterc/SimpleSearch/issues/41