### PR TITLE
Update simplesearchdriverbasic.class.php

### DIFF
--- a/core/components/simplesearch/model/simplesearch/driver/simplesearchdriverbasic.class.php
+++ b/core/components/simplesearch/model/simplesearch/driver/simplesearchdriverbasic.class.php
@@ -232,6 +232,11 @@ class SimpleSearchDriverBasic extends SimpleSearchDriver
         $c->where(array('published:=' => 1), xPDOQuery::SQL_AND, null, $whereGroup);
         $c->where(array('searchable:=' => 1), xPDOQuery::SQL_AND, null, $whereGroup);
         $c->where(array('deleted:=' => 0), xPDOQuery::SQL_AND, null, $whereGroup);
+        
+        if($scriptProperties['template']!='')
+        {
+             $c->where(array('template:IN' => [$scriptProperties['template']]), xPDOQuery::SQL_AND, null, $whereGroup);
+        }
 
         /* Restrict to either this context or specified contexts */
         $ctx = !empty($this->config['contexts']) ? $this->config['contexts'] : $this->modx->context->get('key');


### PR DESCRIPTION
Add support for filtering search by template. 
Use &template=`id` or &tempalte=`id,id,id` 
this solution is helpfull when u need to search by products or etc