### PR TITLE
MODX3 - error message on installation

### DIFF
--- a/_build/resolvers/stercextra.resolver.php
+++ b/_build/resolvers/stercextra.resolver.php
@@ -9,7 +9,7 @@ $c->where(
         'workspace' => 1,
         "(SELECT
             `signature`
-            FROM {$modx->getTableName('modTransportPackage')} AS `latestPackage`
+            FROM {$modx->getTableName('transport.modTransportPackage')} AS `latestPackage`
             WHERE `latestPackage`.`package_name` = `modTransportPackage`.`package_name`
             ORDER BY
                 `latestPackage`.`version_major` DESC,


### PR DESCRIPTION
When installing _SimpleSearch_ on MODX 3.0.0, it outputs the following error message to the installation console:

```
Could not load class: modTransportPackage from mysql.modtransportpackage
Could not get table name for class:
Error 42000 executing statement: Array ( [0] => 42000 [1] => 1064 [2] => You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'AS `latestPackage` WHERE `latestPackage`.`package_name` = `modTra...' at line 3 )
```