### PR TITLE
Fixed disregarding of nested brackets

### DIFF
--- a/core/components/simplesearch/model/simplesearch/simplesearch.class.php
+++ b/core/components/simplesearch/model/simplesearch/simplesearch.class.php
@@ -327,7 +327,7 @@ class SimpleSearch
      */
     public function sanitize($text) {
         $text = strip_tags($text);
-        $text = preg_replace('/(\[\[\+.*?\]\])/i', '', $text);
+        $text = preg_replace('/\[[^][]*+(?:(?R)[^][]*)*+]/i', '', $text);
 
         return $this->modx->stripTags($text);
     }


### PR DESCRIPTION
Nested snippets calls like [[Mysnippet? &prop=`[[$nested]]`]] get ignored as of now.
Most likely linked to #32 