### PR TITLE
Bugfix/issue 36

### DIFF
--- a/core/components/simplesearch/src/SimpleSearch.php
+++ b/core/components/simplesearch/src/SimpleSearch.php
@@ -453,12 +453,12 @@ class SimpleSearch
     public function addHighlighting(string $string, string $cls = 'simplesearch-highlight', string $tag = 'span'): string
     {
         $searchStrings = explode(' ', $this->searchString);
+        $replacement = '<'.$tag.' class="'.$cls.'">$0</'.$tag.'>';
+        $searchParts = [];
         foreach ($searchStrings as $searchString) {
-            $quoteValue = preg_quote($searchString, '/');
-            $string     = preg_replace('/' . $quoteValue . '/i', '<'.$tag.' class="'.$cls.'">$0</'.$tag.'>', $string);
+            $searchParts[] = '(' . preg_quote($searchString, '/') . ')';
         }
-
-        return $string;
+        return preg_replace('/' . implode('|', $searchParts) . '/i', $replacement, $string);
     }
 
     /**


### PR DESCRIPTION
Fixing an issue #36 
The code fix addresses that search terms are highlighted by <span> tag and class. 
If search string contains several segments, each segment is enclosed with <span> element to highlight it. 
Issue is that if search segment matches any part of highlighting tag, it will be enclosed with highlight tag again.
for example:
Search string is "De las" 
The highlighting would work like:
Pass 1: Match "De" in "**De** las" and replace. The result is "<span class='simplesearch-highlight'>De</span> las"
Pass 2: Match "les" in "<span c**las**s='simplesearch-highlight'>De</span> **las**" and replace. The result is: 
`<span c<span class='simplesearch-highlight'>las</span>s='simplesearch-highlight'>De</span> las`

The fix is to highlight each segment of search string separately and then concatenate all segments back to string. 
